### PR TITLE
feat: Add current word to personal corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,27 @@
   "https://github.com/ck-zhang/mistake.nvim",
 }
 ```
+
+### Configuration
+
+If keymaps are wanted for personal corrections, the following configuration snippet can be applied:
+
+```lua
+  {
+    'ck-zhang/mistake.nvim',
+    config = function()
+      local plugin = require 'mistake'
+      vim.defer_fn(function()
+        plugin.setup()
+      end, 500)
+
+      vim.keymap.set('n', '<leader>ma', plugin.add_entry, { desc = '[M]istake [A]dd entry' })
+      vim.keymap.set('n', '<leader>me', plugin.edit_entries, { desc = '[M]istake [E]dit entries' })
+      vim.keymap.set('n', '<leader>mc', plugin.add_entry_under_cursor, { desc = '[M]istake add [C]urrent word' })
+    end,
+  }
+```
+
 ## Personal Corrections
 
 To add your own corrections, use `:MistakeAdd`;

--- a/lua/mistake/init.lua
+++ b/lua/mistake/init.lua
@@ -7,6 +7,7 @@ M.setup = function(opts)
 	default_opts.dict_file = script_path .. "dict.lua"
 
 	default_opts.custom_dict_file = vim.fn.stdpath("config") .. "/mistake_custom_dict.lua"
+	default_opts.replace_after_addition = true
 
 	opts = opts or {}
 	opts = vim.tbl_extend("force", default_opts, opts)
@@ -122,6 +123,17 @@ M.setup = function(opts)
 		print("Custom abbreviations reloaded.")
 	end
 
+	M.replace_in_buffer = function(typo, correction)
+		if opts.replace_after_addition then
+			local original_position = vim.api.nvim_win_get_cursor(0)
+
+			local vim_s_command = ':substitute/\\<' .. typo .. '\\>/' .. correction .. '/gIe'
+			vim.cmd(vim_s_command)
+
+			vim.api.nvim_win_set_cursor(0, original_position)
+		end
+	end
+
 	M.diff_dictionaries = function(old_dict, new_dict)
 		local to_add = {}
 		local to_update = {}
@@ -183,6 +195,7 @@ local function add_typo(typo)
 			file:close()
 			print(" Added to custom dictionary: '" .. typo .. "' -> '" .. correction .. "'")
 			M.reload_custom_abbreviations()
+			M.replace_in_buffer(typo, correction)
 		else
 			print("Error writing to file: " .. M.opts.custom_dict_file)
 		end

--- a/lua/mistake/init.lua
+++ b/lua/mistake/init.lua
@@ -185,7 +185,7 @@ local function add_typo(typo)
 			M.reload_custom_abbreviations()
 		else
 			print("Error writing to file: " .. M.opts.custom_dict_file)
-			end
+		end
 	end)
 end
 

--- a/lua/mistake/init.lua
+++ b/lua/mistake/init.lua
@@ -33,6 +33,10 @@ M.setup = function(opts)
 		M.add_entry()
 	end, {})
 
+	vim.api.nvim_create_user_command("MistakeAddCurrentWord", function()
+		M.add_entry_under_cursor()
+	end, {})
+
 	M.load_abbreviations = function()
 		M.load_chunked_entries(opts.dict_file, 100)
 		M.load_chunked_entries(opts.custom_dict_file, 100)

--- a/lua/mistake/init.lua
+++ b/lua/mistake/init.lua
@@ -191,6 +191,10 @@ M.add_entry = function()
 	vim.ui.input({ prompt = typo_icon .. 'Enter the typo: ' }, add_typo)
 end
 
+M.add_entry_under_cursor = function()
+	add_typo(vim.fn.expand("<cword>"))
+end
+
 M.edit_entries = function()
 	local custom_dict = {}
 	if vim.loop.fs_stat(M.opts.custom_dict_file) then


### PR DESCRIPTION
Hello,

First, this plugin is really nice and contains some cool functionality.

A few years ago, I wrote a plugin called [vim-auto-abbrev](https://github.com/omrisarig13/vim-auto-abbrev), which had similar functionality to the personal corrections part you've implemented here, written in vimscript.  
I've recently switched to neovim, and seen your plugin, which seems superior to my old one.

I've started using it, and found that I'm missing some functionality from my old plugin - mainly the fast turn-around for adding corrections and fixing the current buffer.  
I've forked your repository and added the relevant functionality here.  
(I also have some more ideas for some more small features, but am unsure as to when I'll get to implement any of them).

I think it can be cool if you want to merge this kind of functionality back to your own plugin, and I'd be happy to keep contributing my changes back here.  
It's also completely fair if you don't want to extend the functionality of your own plugin, in that case, I'd not send any more feature merge requests here.

Let me know what you think.